### PR TITLE
Reduce Gemini questions for one item

### DIFF
--- a/sites/write_each_vacancy_to_db.py
+++ b/sites/write_each_vacancy_to_db.py
@@ -54,8 +54,6 @@ class HelperSite_Parser:
 
         # fill in the fields if they are empty using the Gemini neural network
         if check_vacancy_not_exists:
-            if not results_dict['contacts']:
-                self.results_dict['contacts'] = ask_gemini("What contacts?", gemini_prompt)
             if not results_dict['city']:
                 self.results_dict['city'] = ask_gemini("What city?", gemini_prompt)
             if not results_dict['salary']:


### PR DESCRIPTION
Проверка Gemini на предмет наличия контактов в тексте тела вакансии - лишнее действие, нагружающее работу приложения. 
Пока основной донор - hh.ru  и там вероятнее всего нет этих контактов. (просмотрено несколько тысяч вакансий за последние несколько суток. Все просмотренные вакансии имели заполненное нейросетью поле 'contacts' значением "нет данных", следовательно каждая вакансия прошла через не нужное обращение к Gemini.  
![Нет данных от Gemini](https://github.com/RuslanSlepuhin/server_bot/assets/114598390/ef567704-d18b-47ba-90a7-633c515f3c3a)
