### PR TITLE
Remove antitags filter

### DIFF
--- a/filters/filter_jan_2023/filter_jan_2023.py
+++ b/filters/filter_jan_2023/filter_jan_2023.py
@@ -185,7 +185,7 @@ class VacancyFilter:
                     if result['result']:
                         self.profession['sub'][prof].append(result['result'])
 
-    def check_parameter(self, pattern, vacancy, key, low=False, mex=True, only_one_profession_sub=False, check_only_mex=False):
+    def check_parameter(self, pattern, vacancy, key, low=False, mex=False, only_one_profession_sub=False, check_only_mex=False):
         result = 0
         tags = ''
         anti_tags = ''

--- a/filters/filter_jan_2023/filter_jan_2023.py
+++ b/filters/filter_jan_2023/filter_jan_2023.py
@@ -185,7 +185,7 @@ class VacancyFilter:
                     if result['result']:
                         self.profession['sub'][prof].append(result['result'])
 
-    def check_parameter(self, pattern, vacancy, key, low=False, mex=False, only_one_profession_sub=False, check_only_mex=False):
+    def check_parameter(self, pattern, vacancy, key, low=False, mex=True, only_one_profession_sub=False, check_only_mex=False):
         result = 0
         tags = ''
         anti_tags = ''

--- a/utils/additional_variables/additional_variables.py
+++ b/utils/additional_variables/additional_variables.py
@@ -26,7 +26,7 @@ fields_admin_temporary = "id_admin_channel, id_admin_last_session_table, sended_
 additional_elements = {'admin_last_session', 'archive'}
 
 valid_professions = ['junior', 'backend', 'frontend', 'qa', 'devops', 'designer', 'game', 'mobile', 'product', 'pm', 'analyst',
-                      'sales_manager', 'hr', 'marketing']
+                     'marketing', 'sales_manager', 'hr']
 valid_professions_extended = []
 valid_professions_extended.extend(valid_professions)
 valid_professions_extended.extend(['fullstack'])

--- a/utils/additional_variables/additional_variables.py
+++ b/utils/additional_variables/additional_variables.py
@@ -26,7 +26,7 @@ fields_admin_temporary = "id_admin_channel, id_admin_last_session_table, sended_
 additional_elements = {'admin_last_session', 'archive'}
 
 valid_professions = ['junior', 'backend', 'frontend', 'qa', 'devops', 'designer', 'game', 'mobile', 'product', 'pm', 'analyst',
-                     'marketing', 'sales_manager', 'hr']
+                      'sales_manager', 'hr', 'marketing']
 valid_professions_extended = []
 valid_professions_extended.extend(valid_professions)
 valid_professions_extended.extend(['fullstack'])


### PR DESCRIPTION
Временно деактивирован фильтр 'antitags''. Очень много релевантных вакансий отклоняется этим фильтром. 
![Отклоненные по фильтру antitags](https://github.com/RuslanSlepuhin/server_bot/assets/114598390/68bd2abd-0aab-454d-a3d4-ee0b661ba89c)
![photo_2024-04-15_14-12-34](https://github.com/RuslanSlepuhin/server_bot/assets/114598390/84957a5d-56f1-4952-94e4-93d348b44723)
Еще пример
Например:
![Отклонена вакансия дизайнера](https://github.com/RuslanSlepuhin/server_bot/assets/114598390/7ed13af3-0337-444c-b136-b595911a88a7)
Вакансия отклонена, т.к. в тексте содержится слово "редактор"