### PR TITLE
Remove Gemini check if that's a vacancy

### DIFF
--- a/sites/write_each_vacancy_to_db.py
+++ b/sites/write_each_vacancy_to_db.py
@@ -42,7 +42,7 @@ class HelperSite_Parser:
 
         # check weather this is a vacancy and, if so, weather it relates to IT using Gemini
         gemini_prompt = results_dict['title'] + results_dict['body']
-        for question in ["Is vacancy?", "Is IT?"]:
+        for question in ["Is IT?"]:
             answer = ask_gemini(question, gemini_prompt)
             if search(r"[Нн]е ", answer) or search(r"[Нн]ет", answer):
                 check_vacancy_not_exists = False


### PR DESCRIPTION
Временно удален запрос к Gemini  на предмет вакансия ли это. Поскольку на сегодня основной донор - hh.ru
в процессе парсинга не было замечено левого содержимого вместо текста вакансии, но через лишний запрос  к нейросети все вакансии проходят. 