### PR TITLE
Disable snippets in hh.ru scraper

### DIFF
--- a/sites/scraping_hh.py
+++ b/sites/scraping_hh.py
@@ -74,7 +74,7 @@ class HHGetInformation:
         self.debug = False
         self.additional = (f"/search/vacancy?"
                            f"search_field=name&"       # Искать совпадениев названии вакансии
-                           f"enable_snippets=true&"    # с ревью вакансий в поисковой выдаче
+                           f"enable_snippets=false&"   # без ревью вакансий в поисковой выдаче
                            f"ored_clusters=true&"      # 
                            f"search_period=3&"         # за последние 3 дня
                            f"text=**word&"             # по ключевому слову


### PR DESCRIPTION
Удаление краткого обзора вакансий в поисковой выдаче. 
Выглядит данное изменение так.
![Удаление превью в поисковой выдаче](https://github.com/RuslanSlepuhin/server_bot/assets/114598390/761f90c7-97e7-419c-89d2-524ea91aa53b)
 