### PR TITLE
Fix searching area in scraping_hh.ru

### DIFF
--- a/sites/scraping_hh.py
+++ b/sites/scraping_hh.py
@@ -75,6 +75,7 @@ class HHGetInformation:
         self.additional = (f"/search/vacancy?"
                            f"search_field=name&"       # Искать совпадениев названии вакансии
                            f"enable_snippets=true&"    # с ревью вакансий в поисковой выдаче
+                           f"area=0&"                  # по всем регионам
                            f"ored_clusters=true&"      # 
                            f"search_period=3&"         # за последние 3 дня
                            f"text=**word&"             # по ключевому слову


### PR DESCRIPTION
Жестко зафиксирована локация для поискового запроса в hh.ru
Есть подозрение, что при отправке поискового запроса происходит коррекция региона поиска в соответствии с тем местом, где находится сервер. В итоге поисковая выдача значительно сокращается. 