### PR TITLE
Replace symbols in chat name before publishing.

### DIFF
--- a/invite_bot_ver2.py
+++ b/invite_bot_ver2.py
@@ -679,6 +679,7 @@ class InviteBot():
                 cut_name = chat_name[0]
                 cut_name = (cut_name
                             .replace("https://", "")
+                            .replace("en/jobs", "")
                             .replace("/ru", "")
                             .replace("/", "")
                             .replace("www.", "")


### PR DESCRIPTION
Подрезка имени чата перед публикацией в Телеграм 