### PR TITLE
Fix careerspace parser.

### DIFF
--- a/sites/scraping_careerspace.py
+++ b/sites/scraping_careerspace.py
@@ -14,7 +14,6 @@ from utils.additional_variables.additional_variables import admin_database, arch
 class CareerSpaceGetInformation:
 
     def __init__(self, **kwargs):
-
         self.report = kwargs['report'] if 'report' in kwargs else None
         self.search_words = kwargs['search_word'] if 'search_word' in kwargs else None
         self.bot_dict = kwargs['bot_dict'] if 'bot_dict' in kwargs else None
@@ -35,7 +34,6 @@ class CareerSpaceGetInformation:
         self.found_by_link = 0
         self.response = None
         self.current_session = None
-    
 
     async def get_content(self, db_tables=None):
         self.db_tables = db_tables
@@ -50,8 +48,7 @@ class CareerSpaceGetInformation:
             try:
                 await self.report.add_to_excel()
                 await self.helper.send_file_to_user(
-                    bot=self.bot,
-                    chat_id=self.chat_id,
+                    bot=self.bot, chat_id=self.chat_id,
                     path=self.report.keys.report_file_path['parsing'],
                 )
             except Exception as ex:
@@ -67,12 +64,18 @@ class CareerSpaceGetInformation:
                 options=options
             )
         except:
-            self.browser = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
-
+            self.browser = webdriver.Chrome(
+                service=Service(
+                    ChromeDriverManager().install()),
+                options=options
+            )
         self.current_session = await self.helper_parser_site.get_name_session() if self.db else None
-
         if self.bot_dict:
-            await self.bot.send_message(self.chat_id, 'https://careerspace.app', disable_web_page_preview=True)
+            await self.bot.send_message(
+                self.chat_id,
+                'https://careerspace.app',
+                disable_web_page_preview=True
+            )
         self.browser.get('https://careerspace.app/jobs?'
                          'functions%5B%5D=8&'
                          'functions%5B%5D=14&'
@@ -94,14 +97,12 @@ class CareerSpaceGetInformation:
     async def get_link_message(self, raw_content):
         soup = BeautifulSoup(raw_content, 'lxml')
         open_links = soup.find_all('div', class_='job-card job-card job-card--main')
-
         self.list_links = list(set(open_links))
 
         if self.list_links:
             if self.bot_dict:
                 self.current_message = await self.bot.send_message(self.chat_id,
-                                                               f'careerspace.app:\nНайдено {len(self.list_links)} вакансий',
-                                                               disable_web_page_preview=True)
+                    f'careerspace.app:\nНайдено {len(self.list_links)} вакансий', disable_web_page_preview=True)
             # --------------------- LOOP -------------------------
             self.written_vacancies = 0
             self.rejected_vacancies = 0
@@ -130,7 +131,6 @@ class CareerSpaceGetInformation:
                 vacancy_url = link
                 print(f"\n{vacancy_url}\n")
 
-            # pre-checking by link
             if self.db:
                 check_vacancy_not_exists = self.db.check_exists_message_by_link_or_url(
                     vacancy_url=vacancy_url,
@@ -167,10 +167,8 @@ class CareerSpaceGetInformation:
                         job_info = []
                         inner_div = soup.find('div', class_='j-d-h__cities cs-df-alc')
                         city_span = inner_div.find_all('span', class_='job-lb cs-df-alc job-lb--df')
-
                         for span in city_span:
                             print(span.get_text().strip())
-
                         for span in city_span:
                             job_info.append(span.get_text(strip=True))
                         city = []
@@ -180,7 +178,6 @@ class CareerSpaceGetInformation:
                                 job_format.append(job_info[i])
                             else:
                                 city.append(job_info[i])
-
                     except AttributeError as ex:
                         job_format = None
                         city = None
@@ -205,7 +202,6 @@ class CareerSpaceGetInformation:
                     relocation = ''
                     if re.findall(r'[Rr]elocation', body):
                         relocation = 'релокация'
-
                     if self.db:
                         self.db.write_to_db_companies([company])
 
@@ -217,13 +213,19 @@ class CareerSpaceGetInformation:
                         time_of_public = time_of_public.split("Дата публикации: ")
                         time_of_public = time_of_public.pop(1).replace(".", "")
                         months = {
-                            "января": "january", "февраля": "february",
-                            "марта": "march", "апреля": "april",
-                            "мая": "may", "июня": "june",
-                            "июля": "july", "августа":"august",
-                            "сентября":"september", "октября": "october",
-                            "ноября": "november", "декабря": "december"
-                                  }
+                            "января": "january",
+                            "февраля": "february",
+                            "марта": "march",
+                            "апреля": "april",
+                            "мая": "may",
+                            "июня": "june",
+                            "июля": "july",
+                            "августа": "august",
+                            "сентября": "september",
+                            "октября": "october",
+                            "ноября": "november",
+                            "декабря": "december"
+                        }
                         for ru_month, en_month in months.items():
                             if ru_month in time_of_public:
                                 published_at = time_of_public.replace(ru_month, en_month)
@@ -233,9 +235,7 @@ class CareerSpaceGetInformation:
                         time_of_public = ""
                         print(f"AttributeError occurred: {ex}")
 
-
                     # -------------------- compose one writting for ione vacancy ----------------
-
                     results_dict = {
                         'chat_name': 'https://careerspace.app/',
                         'title': title,
@@ -257,93 +257,40 @@ class CareerSpaceGetInformation:
                     return_raw_dictionary = False
                     if not return_raw_dictionary:
                         response = await self.helper_parser_site.write_each_vacancy(results_dict)
-
                         print('sort profession (33)')
                         await self.output_logs(
                             about_vacancy=response,
                             vacancy=vacancy,
                             vacancy_url=vacancy_url
                         )
-                        # return response
                         self.response = response
                     else:
                         self.response = results_dict
             else:
                 self.found_by_link += 1
                 print("vacancy link exists")
-
         if self.found_by_link > 0:
             self.count_message_in_one_channel += self.found_by_link
             if self.bot_dict:
-                self.current_message = await self.helper.edit_message(
-                    bot=self.bot,
-                    text=f"\n---\nfound by link: {self.found_by_link}",
-                    msg=self.current_message
-                )
+                self.current_message = await self.helper.edit_message(bot=self.bot,
+                    text=f"\n---\nfound by link: {self.found_by_link}", msg=self.current_message)
 
     async def get_content_from_one_link(self, vacancy_url):
         try:
-            self.browser = webdriver.Chrome(
-                executable_path=chrome_driver_path,
-                options=options
-            )
+            self.browser = webdriver.Chrome(executable_path=chrome_driver_path, options=options)
         except:
             self.browser = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
         # -------------------- check what is current session --------------
         self.current_session = await self.helper_parser_site.get_name_session()
-        self.list_links= [vacancy_url]
+        self.list_links = [vacancy_url]
         await self.get_content_from_link()
         self.browser.quit()
         return self.response
-
-    def clean_company_name(self, text):
-        text = re.sub('Прямой работодатель', '', text)
-        text = re.sub(r'[(]{1} [a-zA-Z0-9\W\.]{1,30} [)]{1}', '', text)
-        text = re.sub(r'Аккаунт зарегистрирован с (публичной почты|email) \*@[a-z.]*[, не email компании!]{0,1}', '',
-                      text)
-        text = text.replace(f'\n', '')
-        return text
-
-    def normalize_vacancy(self, raw_vacancy):
-        vacancy = re.sub(r'креативного', 'креативный', raw_vacancy)
-        vacancy = re.sub(r'графического', 'графический', vacancy)
-        vacancy = re.sub(r'коммуникационного', 'коммуникационный', vacancy)
-        vacancy = re.sub(r'продуктового', 'продуктовый', vacancy)
-        vacancy = re.sub(r'старшего', 'старший', vacancy)
-        vacancy = re.sub(r'технического', 'технический', vacancy)
-        vacancy = re.sub(r'главного', 'главный', vacancy)
-        vacancy = re.sub(r'ведущего', 'ведущий', vacancy)
-
-        vacancy = re.sub(r'дизайнера', 'дизайнер', vacancy)
-        vacancy = re.sub(r'дира', 'дир', vacancy)
-        vacancy = re.sub(r'архитектора', 'архитектор', vacancy)
-        vacancy = re.sub(r'директора', 'директор', vacancy)
-        vacancy = re.sub(r'аэрографиста', 'аэрографист', vacancy)
-        vacancy = re.sub(r'супервайзера', 'супервайзер', vacancy)
-        vacancy = re.sub(r'графика', 'график', vacancy)
-        vacancy = re.sub(r'лида', 'лид', vacancy)
-        vacancy = re.sub(r'фоторедактора', 'фоторедактор', vacancy)
-        vacancy = re.sub(r'координатора', 'координатор', vacancy)
-        vacancy = re.sub(r'иллюстратора', 'иллюстратор', vacancy)
-        vacancy = re.sub(r'руководителя', 'руководитель', vacancy)
-        vacancy = re.sub(r'конструктора', 'конструктор', vacancy)
-        vacancy = re.sub(r'верстальщика', 'верстальщик', vacancy)
-        vacancy = re.sub(r'художника', 'художник', vacancy)
-        vacancy = re.sub(r'лого-мейкера', 'лого-мейкер', vacancy)
-
-        vacancy = re.sub(r'ого\b', '', vacancy)
-        vacancy = re.sub(r'eго\b', '', vacancy)
-
-        if vacancy == raw_vacancy:
-            vacancy = 'дизайнер'
-        return vacancy
-
 
     async def write_to_db_table_companies(self):
         excel_data_df = pd.read_excel('all_geek.xlsx', sheet_name='Sheet1')
         companies = excel_data_df['hiring'].tolist()
         links = excel_data_df['access_hash'].tolist()
-
         companies = set(companies)
         if self.db:
             self.db.write_to_db_companies(companies)
@@ -354,11 +301,9 @@ class CareerSpaceGetInformation:
         if about_vacancy['response']['vacancy'] in ['found in db by link', 'found in db by title-body']:
             additional_message = f'-exists in db\n\n'
             self.rejected_vacancies += 1
-
         elif about_vacancy['response']['vacancy'] == 'no vacancy by anti-tags':
             additional_message = f'-ANTI-TAG by vacancy\n\n'
             self.rejected_vacancies += 1
-
         elif about_vacancy['response']['vacancy'] == 'written to db':
             if about_vacancy['profession']:
                 profession = about_vacancy['profession']
@@ -368,22 +313,12 @@ class CareerSpaceGetInformation:
             else:
                 additional_message = 'written to db'
                 self.written_vacancies += 1
-
         if self.bot_dict and self.helper:
             if len(f"{self.current_message}\n{self.count_message_in_one_channel}. {vacancy}\n{additional_message}") < 4096:
                 new_text = f"\n{self.count_message_in_one_channel}. {vacancy}\n{additional_message}"
-
-                self.current_message = await self.helper.edit_message(
-                    bot=self.bot,
-                    text=new_text,
-                    msg=self.current_message
-                )
+                self.current_message = await self.helper.edit_message(bot=self.bot, text=new_text,
+                    msg=self.current_message)
             else:
                 new_text = f"{self.count_message_in_one_channel}. {vacancy}\n{additional_message}"
-                self.current_message = await self.helper.send_message(
-                    bot=self.bot,
-                    chat_id=self.chat_id,
-                    text=new_text
-                )
-
+                self.current_message = await self.helper.send_message(bot=self.bot, chat_id=self.chat_id, text=new_text)
         self.count_message_in_one_channel += 1

--- a/sites/scraping_careerspace.py
+++ b/sites/scraping_careerspace.py
@@ -1,5 +1,6 @@
 import re
-from datetime import datetime, timedelta
+import time
+from datetime import datetime
 import pandas as pd
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
@@ -34,6 +35,7 @@ class CareerSpaceGetInformation:
         self.found_by_link = 0
         self.response = None
         self.current_session = None
+    
 
     async def get_content(self, db_tables=None):
         self.db_tables = db_tables
@@ -65,20 +67,23 @@ class CareerSpaceGetInformation:
                 options=options
             )
         except:
-            try:
-                self.browser = webdriver.Chrome(
-                    executable_path=chrome_driver_path,
-                    options=options
-                )
-            except:
-                self.browser = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+            self.browser = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
 
         self.current_session = await self.helper_parser_site.get_name_session() if self.db else None
 
         if self.bot_dict:
             await self.bot.send_message(self.chat_id, 'https://careerspace.app', disable_web_page_preview=True)
-        self.browser.get('https://careerspace.app')
-        self.browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+        self.browser.get('https://careerspace.app/jobs?'
+                         'functions%5B%5D=8&'
+                         'functions%5B%5D=14&'
+                         'functions%5B%5D=7&'
+                         'functions%5B%5D=19&'
+                         'functions%5B%5D=13&'
+                         'area=everywhere&'
+                         'isPreFilter=true')
+        for _ in range(50):
+            self.browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+            time.sleep(2)
         try:
             vacancy_exists_on_page = await self.get_link_message(self.browser.page_source)
         except:
@@ -88,7 +93,7 @@ class CareerSpaceGetInformation:
 
     async def get_link_message(self, raw_content):
         soup = BeautifulSoup(raw_content, 'lxml')
-        open_links = soup.find_all('div', class_='job-card')
+        open_links = soup.find_all('div', class_='job-card job-card job-card--main')
 
         self.list_links = list(set(open_links))
 
@@ -107,8 +112,6 @@ class CareerSpaceGetInformation:
                 if self.bot:
                     await self.bot.send_message(self.chat_id, f"Error: {e}")
             # ----------------------- the statistics output ---------------------------
-            # self.written_vacancies = 0
-            # self.rejected_vacancies = 0
             return True
         else:
             return False
@@ -144,36 +147,29 @@ class CareerSpaceGetInformation:
 
                 if found_vacancy:
                     try:
-                        vacancy = soup.find("h3", class_="cs-t--title28").text.strip()
+                        vacancy = soup.find("h1", attrs={"data-testid": "csu-title"}).text
                     except AttributeError as ex:
-                        vacancy = None
+                        vacancy = ""
                         print(f"Exception occurred: {ex}")
 
                     # get title --------------------------
-                    try:
-                        title = soup.find("title").text.strip()
-                    except (AttributeError, TypeError) as ex:
-                        title = None
-                        print(f"Exception occurred: {ex}")
+                    title = vacancy
 
                     # get body --------------------------
                     try:
-                        body = soup.find("div", class_="j-d-desc").text.strip()
+                        body = soup.find("div", class_="j-d__dsc-vl").text.strip()
                     except AttributeError as ex:
                         body = None
                         print(f"Exception occurred: {ex}")
 
                     # get city and job_format --------------
                     try:
-
-
                         job_info = []
-                        inner_div = soup.find('div', class_='j-d-h__inner')  # Находим блокf <div class="j-d-h__inner">
-                        city_span = inner_div.find_all('span',
-                                                       class_='job-lb__tx')  # Ищем блоки <span class="job-lb__tx">
+                        inner_div = soup.find('div', class_='j-d-h__cities cs-df-alc')
+                        city_span = inner_div.find_all('span', class_='job-lb cs-df-alc job-lb--df')
 
                         for span in city_span:
-                            print(span.get_text().strip())  # Выводим текст из каждого найденного блока <span>
+                            print(span.get_text().strip())
 
                         for span in city_span:
                             job_info.append(span.get_text(strip=True))
@@ -192,26 +188,51 @@ class CareerSpaceGetInformation:
 
                     # get company -------------------------
                     try:
-                        company = soup.find("div", class_="j-d-h__company").text.strip()
+                        company_div = soup.find("div", class_="j-d-h__bl cs-df-alc-jsb")
+                        company = company_div.find("span", attrs={"data-v-27ef1e69": ""}).text
                     except AttributeError as ex:
                         company = None
                         print(f"Exception occurred: {ex}")
 
                     # get salary --------------------------
                     try:
-                        salary = soup.find("span", class_="price").text.strip()
+                        salary = soup.find("div", class_="price").text.strip()
                     except AttributeError as ex:
                         salary = None
                         print(f"AttributeError occurred: {ex}")
 
-
-                    # ------------------------- search relocation ----------------------------
+                    # get relocation ------------------------
                     relocation = ''
                     if re.findall(r'[Rr]elocation', body):
                         relocation = 'релокация'
 
                     if self.db:
                         self.db.write_to_db_companies([company])
+
+                    # get time of public --------------------
+                    time_of_public, published_at = "", ""
+                    try:
+                        time_of_public = soup.find("meta", attrs={"name": "description"})
+                        time_of_public = time_of_public.get("content")
+                        time_of_public = time_of_public.split("Дата публикации: ")
+                        time_of_public = time_of_public.pop(1).replace(".", "")
+                        months = {
+                            "января": "january", "февраля": "february",
+                            "марта": "march", "апреля": "april",
+                            "мая": "may", "июня": "june",
+                            "июля": "july", "августа":"august",
+                            "сентября":"september", "октября": "october",
+                            "ноября": "november", "декабря": "december"
+                                  }
+                        for ru_month, en_month in months.items():
+                            if ru_month in time_of_public:
+                                published_at = time_of_public.replace(ru_month, en_month)
+                                break
+                        time_of_public = datetime.strptime(published_at, "%d %B %Y")
+                    except AttributeError as ex:
+                        time_of_public = ""
+                        print(f"AttributeError occurred: {ex}")
+
 
                     # -------------------- compose one writting for ione vacancy ----------------
 
@@ -229,11 +250,10 @@ class CareerSpaceGetInformation:
                         'city': city,
                         'salary': salary,
                         'experience': '',
-                        'time_of_public': '',
+                        'time_of_public': time_of_public,
                         'contacts': '',
                         'session': self.current_session
                     }
-                    #print(results_dict)
                     return_raw_dictionary = False
                     if not return_raw_dictionary:
                         response = await self.helper_parser_site.write_each_vacancy(results_dict)
@@ -275,31 +295,6 @@ class CareerSpaceGetInformation:
         await self.get_content_from_link()
         self.browser.quit()
         return self.response
-
-    def normalize_date(self, date):
-        convert = {
-            'янв': '01',
-            'фев': '02',
-            'мар': '03',
-            'апр': '04',
-            'май': '05',
-            'июн': '06',
-            'июл': '07',
-            'авг': '08',
-            'сен': '09',
-            'окт': '10',
-            'ноя': '11',
-            'дек': '12',
-        }
-
-        date = date.split(f' ')
-        month = date[1]
-        day = date[0]
-
-        year = datetime.now().strftime('%Y')
-        date = datetime(int(year), int(convert[month]), int(day), 12, 00, 00)
-
-        return date
 
     def clean_company_name(self, text):
         text = re.sub('Прямой работодатель', '', text)
@@ -392,5 +387,3 @@ class CareerSpaceGetInformation:
                 )
 
         self.count_message_in_one_channel += 1
-
-

--- a/sites/scraping_careerspace.py
+++ b/sites/scraping_careerspace.py
@@ -92,7 +92,11 @@ class CareerSpaceGetInformation:
         except:
             pass
         if self.bot_dict:
-            await self.bot.send_message(self.chat_id, 'careerspace.app parsing: Done!', disable_web_page_preview=True)
+            await self.bot.send_message(
+                self.chat_id,
+                'careerspace.app parsing: Done!',
+                disable_web_page_preview=True
+            )
 
     async def get_link_message(self, raw_content):
         soup = BeautifulSoup(raw_content, 'lxml')
@@ -101,8 +105,11 @@ class CareerSpaceGetInformation:
 
         if self.list_links:
             if self.bot_dict:
-                self.current_message = await self.bot.send_message(self.chat_id,
-                    f'careerspace.app:\nНайдено {len(self.list_links)} вакансий', disable_web_page_preview=True)
+                self.current_message = await self.bot.send_message(
+                    self.chat_id,
+                    f'careerspace.app:\nНайдено {len(self.list_links)} вакансий',
+                    disable_web_page_preview=True
+                )
             # --------------------- LOOP -------------------------
             self.written_vacancies = 0
             self.rejected_vacancies = 0


### PR DESCRIPTION
Ремонт парсера сайта careerspace.app
1. Исправлен запуск парсера
2. Добавлен необходимый скроллинг страниц (без него производился парсинг только 8 вакансий, сейчас будет просмотр 408 вакансий)
3. Исправлено чтение списка ссылок из поисковой выдачи
4. Добавлен встроенный в сайт фильтр для поиска ИТ вакансий
5. Добавлена возможность читать дату публикации вакансии
6. Исправлено чтение заголовка вакансии
7. Исправлено чтение города
8. Исправлено чтение названия компании
9. Исправлено чтение формата работы