### PR TITLE
Add example nginx ports configuration.

### DIFF
--- a/_apps/itcoty_web/example.env
+++ b/_apps/itcoty_web/example.env
@@ -13,7 +13,6 @@ DEFAULT_DB_NAME=postgres
 LOCAL_DB_VERSION=16
 WINDOWS_DB_PATH=C:\Program Files\Postgresql\
 
-
 LOCALHOST=http://127.0.0.1
 DEV_4SERVER=the_project_dev_server
 PROD_SERVER=the_project_prod_server
@@ -28,3 +27,6 @@ EMAIL_DEFAULT_THEME=Django_auth>>
 
 GITHUB_USERNAME=your_github_username
 GITHUB_TOKEN=ghp_PLdbtmFZBlvadgqetETABGsbG4iFGDBHGz
+
+NGINX_HTTP_PORT=80
+NGINX_HTTPS_PORT=443


### PR DESCRIPTION
#### Description:
The external ports for the Nginx container might vary different depending on the environment in which they are running. 
It's not possible to run the container listening on port 80 on the production server.